### PR TITLE
#7 - 가짜 데이터 자료형 enum 설계

### DIFF
--- a/src/main/java/org/example/koreandatatest/domain/SchemaField.java
+++ b/src/main/java/org/example/koreandatatest/domain/SchemaField.java
@@ -3,6 +3,7 @@ package org.example.koreandatatest.domain;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.example.koreandatatest.domain.constant.MockDataType;
 
 @Getter
 @Setter
@@ -10,7 +11,7 @@ import lombok.ToString;
 public class SchemaField {
 
   private String fieldName;
-  private String mockDataType;
+  private MockDataType mockDataType; // enum을 다룰 수 있게끔
   private Integer fieldOrder;
   private Integer blackPercent;
   private String typeOptionJson; // JSON 형태로 저장 {min: 1, max: 10, ...}

--- a/src/main/java/org/example/koreandatatest/domain/constant/MockDataType.java
+++ b/src/main/java/org/example/koreandatatest/domain/constant/MockDataType.java
@@ -1,0 +1,43 @@
+package org.example.koreandatatest.domain.constant;
+
+import java.util.Set;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+@Getter
+@RequiredArgsConstructor // 생성자를 자동으로 생성해주는 어노테이션
+public enum MockDataType { // enum 클래스
+  STRING(Set.of("minLength", "maxLength", "pattern"), null), // 기본 타입은 null
+  DATETIME(Set.of("from", "to"), null),
+  NUMBER(Set.of("min", "max", "decimal"), null),
+  ENUM(Set.of("elements"), null),
+  BOOLEAN(Set.of(), null),
+
+  SENTENCE(Set.of("minSentences", "maxSentences"), STRING),
+  PARAGRAPH(Set.of("minParagraph", "maxParagraph"), STRING),
+  UUID(Set.of(), STRING),
+  EMAIL(Set.of(), STRING),
+  CAR(Set.of(), STRING),
+  ROW_NULBER(Set.of("start", "step"), NUMBER),
+  NAME(Set.of(), STRING)
+  ;
+
+  private final Set<String> requiredOptions; // 필수 옵션
+  private final MockDataType baseType; // 기본 타입
+
+  public boolean isBaseType() {return baseType == null;} // 기본 타입인지 확인하는 메서드
+
+  public MockDataTypeObject toObject() {
+    return new MockDataTypeObject(
+        this.name(),
+        this.requiredOptions,
+        this.baseType == null ? null : this.baseType.name() // baseType이 null이 아니면 baseType 이름을 리턴
+    );
+  }
+
+  public record MockDataTypeObject(
+      String name,
+      Set<String> requiredOptions,
+      String baseType
+  ) {}
+
+}

--- a/src/test/java/org/example/koreandatatest/domain/constant/MockDataTypeTest.java
+++ b/src/test/java/org/example/koreandatatest/domain/constant/MockDataTypeTest.java
@@ -1,0 +1,45 @@
+package org.example.koreandatatest.domain.constant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.example.koreandatatest.domain.constant.MockDataType.MockDataTypeObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("[Domain] 테스트 데이터 자료형 테스트")
+class MockDataTypeTest {
+  @Test
+  @DisplayName("자료형이 주어지면, 해당 원소의 이름을 리던한다.")
+  void givenMockDataType_whenReading_thenReturnsEnumElementName() {
+    // given
+    MockDataType mockDataType = MockDataType.STRING;
+
+    // when
+    String elementName = mockDataType.toString();
+
+    // then
+    assertThat(elementName).isEqualTo(MockDataType.STRING.name());
+  }
+
+  @DisplayName("자료형이 주어지면, 해당 원소의 데이터를 리턴한다")
+  @Test
+  void givenMockDataType_whenReading_thenReturnsEnumElementObject() {
+    // given
+    MockDataType mockDataType = MockDataType.STRING;
+    // when
+    MockDataType.MockDataTypeObject result = mockDataType.STRING.toObject();
+
+    // then
+//    assertThat(result.toString()).isEqualTo(
+//        """
+//            {
+//            "name": "STRING",
+//            "requiredOptions": ["minLength", "maxLength", "pattern"],
+//            "baseType": null
+//            }
+//            """
+//    );
+    assertThat(result.toString())
+        .contains("name", "requiredOptions", "baseType");
+  }
+}


### PR DESCRIPTION
이 pr은 가짜 데이터의 자료형 도메인을 enum으로 설계하고, 문자열로 직렬화할 경우에 필요할 것으로 예상하는 정보를 추가로 정의한다.

This closes #4 