### PR TITLE
#10 - 테스트용 인메모리 DB:H2 프로퍼티 셋업

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,8 @@ logging:
 
 spring:
   application.name: korean-data-test # 어플리케이션 이름
+  datasource:
+    url: jdbc:h2:mem:testdb
   jpa: # JPA 설정
     open-in-view: false # OpenEntityManagerInViewFilter 사용 안함
     defer-datasource-initialization: true # 데이터소스 초기화 지연
@@ -17,3 +19,10 @@ spring:
       hibernate:
         format_sql: true # SQL 포맷팅
   sql.init.mode: always # SQL 초기화 모드
+
+---
+
+spring:
+  config.activate.on-profile: test
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MYSQL;DATABASE_TO_LOWER=TRUE


### PR DESCRIPTION
이 작업은 H2 DB를 사용하도록 스프링 부트 프로퍼티를 추가한다.
또한 테스트 프로파일을 별도 마련하여 mysql 호환성 모드로도 h2를 동작시킬 수 있도록 환경을 준비한다.

This closes #5 
