### PR TITLE
#10 - 실제 DB(mysql) 접근을 위한 프로퍼티 설정 및 테스트 설정 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,9 @@ logging:
 spring:
   application.name: korean-data-test # 어플리케이션 이름
   datasource:
-    url: jdbc:h2:mem:testdb
+    url: ${LOCAL_DB_URL} # 데이터소스 URL
+    username: ${LOCAL_DB_USER}
+    password: ${LOCAL_DB_PW}
   jpa: # JPA 설정
     open-in-view: false # OpenEntityManagerInViewFilter 사용 안함
     defer-datasource-initialization: true # 데이터소스 초기화 지연

--- a/src/test/java/org/example/koreandatatest/KoreanDataTestApplicationTests.java
+++ b/src/test/java/org/example/koreandatatest/KoreanDataTestApplicationTests.java
@@ -2,7 +2,9 @@ package org.example.koreandatatest;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class KoreanDataTestApplicationTests {
 


### PR DESCRIPTION
부트 앱이 동작할 때 인메모리 DB 대신 실제 DB를 바라보도록 스프링 프로퍼티를 수정한다.
다만 그대로 DB 접근 정보를 쓰면 보안에 문제가 되므로, 시스템 환경 변수 형태로 넣는다.
이 변경 후에도 테스트가 잘 동작하도록 기본 테스트의 프로파일을 수정한다.

This closes #12